### PR TITLE
fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Utilities for working with VtR XML Files
 
 This repository contains utilities for working with
-[Verilog to Routing](https://verilog-to-routing.org) XML files.
+[Verilog to Routing](https://verilogtorouting.org/) XML files.
 


### PR DESCRIPTION
i hope my guess is right and https://verilogtorouting.org/ was the domain you meant...