### PR TITLE
Parse never_prune model attribute

### DIFF
--- a/vtr_xml_utils/resources/remove-duplicate-models.xsl
+++ b/vtr_xml_utils/resources/remove-duplicate-models.xsl
@@ -10,6 +10,9 @@
       <xsl:for-each select="model[count(. | key('model-by-name', @name)[1]) = 1]">
         <xsl:copy>
           <xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute>
+	  <xsl:if test="@never_prune='true'">
+            <xsl:attribute name="never_prune"><xsl:value-of select="@never_prune"/></xsl:attribute>
+	  </xsl:if>
           <xsl:apply-templates/>
         </xsl:copy>
       </xsl:for-each>


### PR DESCRIPTION
This PR makes sure that the `never_prune` attribute used by VTR after this [PR](https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1484) gets added to the models in the architecture XML.