### PR TITLE
ci: add GitHub Actions workflow 'ci'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+
+
+  Checks:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: symbiflow/actions/checks@main


### PR DESCRIPTION
Close #11

This PR adds a GitHub Actions workflow named 'ci', with a single job (for now). It executes Action symbiflow/actions/checks, which checks the license and python linting.

The checks fails because #10 was not merged yet. See https://github.com/umarcor/vtr-xml-utils/runs/1490874586?check_suite_focus=true